### PR TITLE
Retire MemoryContextResetAndDeleteChildren() macro.

### DIFF
--- a/src/shared_ispell.c
+++ b/src/shared_ispell.c
@@ -633,7 +633,7 @@ dispell_lexize(PG_FUNCTION_ARGS)
 		 * info here
 		 */
 
-		MemoryContextResetAndDeleteChildren(saveInfo.infoCntx);
+		MemoryContextReset(saveInfo.infoCntx);
 		MemSet(info, 0, sizeof(*info));
 
 		init_shared_dict(info, saveInfo.infoCntx, saveInfo.dictFile,


### PR DESCRIPTION
Caused by the following commits in PostgreSQL:
- eaa5808e8ec4e82ce1a87103a6b6f687666e4e4c (PostgreSQL 9.5) Redefine MemoryContextReset() as deleting, not resetting, child contexts.
- 6a72c42fd5af7ada49584694f543eb06dddb4a87 (PostgreSQL 17) Retire MemoryContextResetAndDeleteChildren() macro.